### PR TITLE
Support Generators

### DIFF
--- a/encoder.c
+++ b/encoder.c
@@ -188,7 +188,7 @@ static yajl_gen_status ProcessObject(_YajlEncoder *self, PyObject *object)
     if (PyFloat_Check(object)) {
         return yajl_gen_double(handle, PyFloat_AsDouble(object));
     }
-    if (PyList_Check(object)) {
+    if (PyList_Check(object)||PyGen_Check(object)||PyTuple_Check(object)) {
         /*
          * Recurse and handle the list
          */
@@ -209,22 +209,6 @@ static yajl_gen_status ProcessObject(_YajlEncoder *self, PyObject *object)
         if (status == yajl_gen_in_error_state)
             return status;
         return close_status;
-    }
-    if (PyTuple_Check(object)) {
-        /*
-         * If we have a tuple, convert to a list
-         */
-        Py_ssize_t size = PyTuple_Size(object);
-        PyObject *converted = PyList_New(size);
-        PyObject *item = NULL;
-        unsigned int i = 0;
-
-        for (; i < size; ++i) {
-            item = PyTuple_GetItem(object, i);
-            Py_INCREF(item);
-            PyList_SET_ITEM(converted, (Py_ssize_t)(i), item);
-        }
-        return ProcessObject(self, converted);
     }
     if (PyDict_Check(object)) {
         PyObject *key, *value;

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -95,6 +95,14 @@ class BasicJSONEncodeTests(EncoderBase):
     def test_NestedDictAndList(self):
         self.assertEncodesTo({'key' : {'subkey' : [1,2,3]}},
             '{"key":{"subkey":[1,2,3]}}')
+    def test_Tuple(self):
+        self.assertEncodesTo((1,2), '[1,2]')
+    def test_generator(self):
+        def f():
+            for i in range(10):
+                yield i
+        self.assertEncodesTo(f(), '[0,1,2,3,4,5,6,7,8,9]')
+
 
 
 class LoadsTest(BasicJSONDecodeTests):


### PR DESCRIPTION
Hi,

it seems supporting generators is trivial. Also converting tuples to lists before serialising seems to be redundant. Tested with python 2.6.4 on linux. What did i miss?

Regards,
igor
