### PR TITLE
support .default() method 

### DIFF
--- a/encoder.c
+++ b/encoder.c
@@ -247,6 +247,15 @@ static yajl_gen_status ProcessObject(_YajlEncoder *self, PyObject *object)
         }
         return yajl_gen_map_close(handle);
     }
+    else {
+        object =  PyObject_CallMethod((PyObject *)self, "default", "O", object);
+        if (object==NULL)
+            goto exit;
+        status = ProcessObject(self, object);
+        return status;
+    }
+
+
 
     exit:
         return yajl_gen_in_error_state;
@@ -364,6 +373,15 @@ PyObject *_internal_encode(_YajlEncoder *self, PyObject *obj, yajl_gen_config ge
     _PyString_Resize(&sauc.str, sauc.used);
     return sauc.str;
 #endif
+}
+
+PyObject *py_yajlencoder_default(PYARGS)
+{
+    PyObject *value;
+    if (!PyArg_ParseTuple(args, "O", &value))
+        return NULL;
+    PyErr_SetObject(PyExc_TypeError, PyUnicode_FromString("Not serializable to JSON"));
+    return NULL;
 }
 
 PyObject *py_yajlencoder_encode(PYARGS)

--- a/py_yajl.h
+++ b/py_yajl.h
@@ -96,6 +96,7 @@ extern PyObject *_internal_decode(_YajlDecoder *self, char *buffer, unsigned int
  * Methods defined for the YajlEncoder type in encoder.c
  */
 extern PyObject *py_yajlencoder_encode(PYARGS);
+extern PyObject* py_yajlencoder_default(PYARGS);
 extern int yajlencoder_init(PYARGS);
 extern void yajlencoder_dealloc(_YajlEncoder *self);
 extern PyObject *_internal_encode(_YajlEncoder *self, PyObject *obj, yajl_gen_config config);

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -102,6 +102,13 @@ class BasicJSONEncodeTests(EncoderBase):
             for i in range(10):
                 yield i
         self.assertEncodesTo(f(), '[0,1,2,3,4,5,6,7,8,9]')
+    def test_default(self):
+        class MyEncode(yajl.Encoder):
+            def default(self, obj):
+                return ['foo']
+        rc = MyEncode().encode(MyEncode) #not supported directly -- will call default
+        assert rc == '["foo"]', ('Failed to encode JSON correctly', locals())
+        return True
 
 
 

--- a/yajl.c
+++ b/yajl.c
@@ -40,6 +40,7 @@ static PyMethodDef yajldecoder_methods[] = {
 
 static PyMethodDef yajlencoder_methods[] = {
     {"encode", (PyCFunction)(py_yajlencoder_encode), METH_VARARGS, NULL},
+    {"default", (PyCFunction)(py_yajlencoder_default), METH_VARARGS, NULL},
     {NULL}
 };
 
@@ -68,7 +69,7 @@ static PyTypeObject YajlDecoderType = {
     0,                         /*tp_getattro*/
     0,                         /*tp_setattro*/
     0,                         /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT,        /*tp_flags*/
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE,        /*tp_flags*/
     "Yajl-based decoder",      /* tp_doc */
     0,                     /* tp_traverse */
     0,                     /* tp_clear */
@@ -113,7 +114,7 @@ static PyTypeObject YajlEncoderType = {
     0,                         /*tp_getattro*/
     0,                         /*tp_setattro*/
     0,                         /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT,        /*tp_flags*/
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE,        /*tp_flags*/
     "Yajl-based encoder",      /* tp_doc */
     0,                     /* tp_traverse */
     0,                     /* tp_clear */


### PR DESCRIPTION
Hi,

i implemented support for simplejsons way of extending JSONEncoder. whats still missing is support for object_hook in load -- but that can be done easily enough in python alone if someone needs it.

regards,
Igor
