### PR TITLE
fix for issue 27

### DIFF
--- a/decoder.c
+++ b/decoder.c
@@ -282,7 +282,7 @@ PyObject *py_yajldecoder_decode(PYARGS)
     _YajlDecoder *decoder = (_YajlDecoder *)(self);
     char *buffer = NULL;
     PyObject *pybuffer = NULL;
-    PyObject *alternate = NULL;
+    PyObject *result = NULL;
     Py_ssize_t buflen = 0;
 
     if (!PyArg_ParseTuple(args, "O", &pybuffer))
@@ -291,12 +291,13 @@ PyObject *py_yajldecoder_decode(PYARGS)
     Py_INCREF(pybuffer);
 
     if (PyUnicode_Check(pybuffer)) {
-        if (!(alternate = PyUnicode_AsUTF8String(pybuffer))) {
+        if (!(result = PyUnicode_AsUTF8String(pybuffer))) {
             Py_DECREF(pybuffer);
             return NULL;
         }
         Py_DECREF(pybuffer);
-        pybuffer = alternate;
+        pybuffer = result;
+        result = NULL;
     }
 
     if (PyString_Check(pybuffer)) {
@@ -317,7 +318,10 @@ PyObject *py_yajldecoder_decode(PYARGS)
                 PyUnicode_FromString("Cannot parse an empty buffer"));
         return NULL;
     }
-    return _internal_decode(decoder, buffer, (unsigned int)buflen);
+
+    result = _internal_decode(decoder, buffer, (unsigned int)buflen);
+    Py_DECREF(pybuffer);
+    return result;
 }
 
 int yajldecoder_init(PYARGS)

--- a/decoder.c
+++ b/decoder.c
@@ -281,9 +281,9 @@ PyObject *py_yajldecoder_decode(PYARGS)
 {
     _YajlDecoder *decoder = (_YajlDecoder *)(self);
     char *buffer = NULL;
-    unsigned int buflen = 0;
+    Py_ssize_t buflen = 0;
 
-    if (!PyArg_ParseTuple(args, "z#", &buffer, &buflen))
+    if (utf8_z_hash_arg(self, args, kwargs, &buffer, &buflen))
         return NULL;
 
     if (!buflen) {
@@ -291,7 +291,7 @@ PyObject *py_yajldecoder_decode(PYARGS)
                 PyUnicode_FromString("Cannot parse an empty buffer"));
         return NULL;
     }
-    return _internal_decode(decoder, buffer, buflen);
+    return _internal_decode(decoder, buffer, (unsigned int)buflen);
 }
 
 int yajldecoder_init(PYARGS)

--- a/py_yajl.h
+++ b/py_yajl.h
@@ -101,5 +101,7 @@ extern int yajlencoder_init(PYARGS);
 extern void yajlencoder_dealloc(_YajlEncoder *self);
 extern PyObject *_internal_encode(_YajlEncoder *self, PyObject *obj, yajl_gen_config config);
 
+extern int utf8_z_hash_arg(PYARGS, char **buffer, Py_ssize_t *buflen);
+
 #endif
 

--- a/py_yajl.h
+++ b/py_yajl.h
@@ -101,7 +101,5 @@ extern int yajlencoder_init(PYARGS);
 extern void yajlencoder_dealloc(_YajlEncoder *self);
 extern PyObject *_internal_encode(_YajlEncoder *self, PyObject *obj, yajl_gen_config config);
 
-extern int utf8_z_hash_arg(PYARGS, char **buffer, Py_ssize_t *buflen);
-
 #endif
 

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -331,6 +331,14 @@ class IssueSixteenTest(unittest.TestCase):
         rc = yajl.loads(rc)
         self.assertEquals(rc, dumpable)
 
+
+class IssueTwentySevenTest(unittest.TestCase):
+    "https://github.com/rtyler/py-yajl/issues/27"
+    def runTest(self):
+        u = u'[{"data":"Podstawow\u0105 opiek\u0119 zdrowotn\u0105"}]'
+        self.assertEqual(yajl.loads(yajl.dumps(u)), u)
+
+
 if __name__ == '__main__':
     verbosity = '-v' in sys.argv and 2 or 1
     runner = unittest.TextTestRunner(verbosity=verbosity)

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -336,7 +336,9 @@ class IssueTwentySevenTest(unittest.TestCase):
     "https://github.com/rtyler/py-yajl/issues/27"
     def runTest(self):
         u = u'[{"data":"Podstawow\u0105 opiek\u0119 zdrowotn\u0105"}]'
-        self.assertEqual(yajl.loads(yajl.dumps(u)), u)
+        self.assertEqual(
+                yajl.dumps(yajl.loads(u)),
+                '[{"data":"Podstawow\\u0105 opiek\\u0119 zdrowotn\\u0105"}]')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
removes use of the "z#" type specifier in argument parsing, as that uses the default encoding for unicode objects. instead, encode unicode to strings ourselves and get the buffer and length with PyString_AsStringAndSize.
