### PR TITLE
Undefined Symbols in python3.2

### DIFF
--- a/py_yajl.h
+++ b/py_yajl.h
@@ -39,6 +39,8 @@
 
 #if PY_MAJOR_VERSION >= 3
 #define IS_PYTHON3
+#define PyString_AsStringAndSize 	PyBytes_AsStringAndSize
+#define PyString_Check				PyBytes_Check
 #endif
 
 typedef struct {


### PR DESCRIPTION
Hi,

Py-yajl would build on my system but would fail on import because of undefined symbols.  I added two defines to the python3 if in py_yajl.h to fix this.  I had tried using PyUnicode objects instead of PyBytes, but I had more undefined symbol issues.  If I missed something and you thing Unicode would be the way to handle this, let me know and I will change the Bytes to Unicode. 

All the best,

~Rickey
