### PR TITLE
Iterate over a stream of json objects + support new yajl version + bug fixes

### DIFF
--- a/BUILDING.markdown
+++ b/BUILDING.markdown
@@ -4,5 +4,5 @@ Getting started building py-yajl
 1. clone this repository
 2. `git submodule update --init`
 3. `python setup.py build_ext --inplace`
-4. `python tests.py`
+4. `runtests.sh`
 

--- a/decoder.c
+++ b/decoder.c
@@ -391,8 +391,6 @@ PyObject *py_yajldecoder_iternext(PyObject *self)
         }
 #endif
 
-        Py_INCREF(buffer);
-
 #ifdef IS_PYTHON3
         result = _internal_decode((_YajlDecoder *)d, PyBytes_AsString(bufferstring),
                   PyBytes_Size(bufferstring));

--- a/decoder.c
+++ b/decoder.c
@@ -493,9 +493,11 @@ int yajldecoder_init(PyObject *self, PyObject *args, PyObject *kwargs)
     py_yajl_ps_init(me->keys); 
 
     // stream setup
-    if (!PyObject_HasAttrString(stream,"read")) {
-        PyErr_SetObject(PyExc_TypeError, PyUnicode_FromString("stream object must have a read attribute"));
-        return -1;
+    if (stream) {
+        if (!PyObject_HasAttrString(stream,"read")) {
+            PyErr_SetObject(PyExc_TypeError, PyUnicode_FromString("stream object must have a read attribute"));
+            return -1;
+        }
     }
 
     me->stream = stream;

--- a/decoder.c
+++ b/decoder.c
@@ -493,6 +493,11 @@ int yajldecoder_init(PyObject *self, PyObject *args, PyObject *kwargs)
     py_yajl_ps_init(me->keys); 
 
     // stream setup
+    if (!PyObject_HasAttrString(stream,"read")) {
+        PyErr_SetObject(PyExc_TypeError, PyUnicode_FromString("stream object must have a read attribute"));
+        return -1;
+    }
+
     me->stream = stream;
     if (bufsize) {
 #ifdef IS_PYTHON3

--- a/decoder.c
+++ b/decoder.c
@@ -249,9 +249,7 @@ PyObject *_internal_decode(_YajlDecoder *self, char *buffer, unsigned int buflen
                 PyUnicode_FromString(yajl_status_to_string(yrc)));
         return NULL;
     }
-
-    Py_INCREF(Py_None);
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 /*
@@ -442,8 +440,7 @@ PyObject *py_yajldecoder_reset(_YajlDecoder *self,PyObject *args)
         yajl_config(self->parser,yajl_allow_multiple_values,1);
     }
 
-    Py_INCREF(Py_None);
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 /*
@@ -480,6 +477,7 @@ int yajldecoder_init(PyObject *self, PyObject *args, PyObject *kwargs)
         }
     } else {
         // default to false
+        Py_INCREF(Py_False);
         allow_multiple_values = Py_False;
     }
 

--- a/decoder.c
+++ b/decoder.c
@@ -337,6 +337,11 @@ PyObject *py_yajldecoder_decode(PYARGS)
     return result;
 }
 
+Py_ssize_t decoder_len(_YajlDecoder *self)
+{
+    return PySequence_Size(self->decoded_objects);
+}
+
 int yajldecoder_init(PYARGS)
 {
     PyObject *allow_multiple_values = NULL;

--- a/decoder.c
+++ b/decoder.c
@@ -258,6 +258,7 @@ PyObject *_internal_decode(_YajlDecoder *self, char *buffer, unsigned int buflen
     yrc = yajl_parse(parser, (const unsigned char *)(buffer), buflen);
 
     if (yrc != yajl_status_ok) {
+        yajl_free(parser);
         PyErr_SetObject(PyExc_ValueError,
                 PyUnicode_FromString(yajl_status_to_string(yrc)));
         return NULL;

--- a/decoder.c
+++ b/decoder.c
@@ -507,13 +507,14 @@ int yajldecoder_init(PyObject *self, PyObject *args, PyObject *kwargs)
             return -1;
         }
 #ifdef IS_PYTHON3
-        if (PyLong_AsLong(bufsize) < 1) {
+        if (!(PyLong_AsLong(bufsize) >= 1)) {
 #else
-        if (!PyInt_Check(bufsize) < 1) {
+        if (!(PyInt_AsLong(bufsize) >=  1)) {
 #endif
-            PyErr_SetObject(PyExc_TypeError, PyUnicode_FromString("bufsize must be > 1"));
+            PyErr_SetObject(PyExc_TypeError, PyUnicode_FromString("bufsize must be >= 1"));
             return -1;
         }
+        me->bufsize = bufsize;
     } else {
 #ifdef IS_PYTHON3
         me->bufsize = PyLong_FromLong(512);

--- a/encoder.c
+++ b/encoder.c
@@ -142,7 +142,9 @@ static yajl_gen_status ProcessObject(_YajlEncoder *self, PyObject *object)
             }
         }
         buffer[offset] = '\0';
-        return yajl_gen_raw_string(handle, (const char *)(buffer), (unsigned int)(offset));
+        status = yajl_gen_raw_string(handle, (const char *)(buffer), (unsigned int)(offset));
+        free(buffer);
+        return status;
     }
 #ifdef IS_PYTHON3
     if (PyBytes_Check(object)) {

--- a/encoder.c
+++ b/encoder.c
@@ -308,12 +308,12 @@ static PyObject * lowLevelStringAlloc(Py_ssize_t size)
 #ifdef IS_PYTHON3
     PyBytesObject * op = (PyBytesObject *)PyObject_MALLOC(sizeof(PyBytesObject) + size);
     if (op) {
-        PyObject_INIT_VAR(op, &PyBytes_Type, size);
+        (void) PyObject_INIT_VAR(op, &PyBytes_Type, size);
     }
 #else
     PyStringObject * op = (PyStringObject *)PyObject_MALLOC(sizeof(PyStringObject) + size);
     if (op) {
-        PyObject_INIT_VAR(op, &PyString_Type, size);
+        (void) PyObject_INIT_VAR(op, &PyString_Type, size);
         op->ob_shash = -1;
         op->ob_sstate = SSTATE_NOT_INTERNED;
     }

--- a/py_yajl.h
+++ b/py_yajl.h
@@ -35,6 +35,7 @@
 
 #include <Python.h>
 #include <yajl/yajl_gen.h>
+#include <yajl/yajl_parse.h>
 #include "ptrstack.h"
 
 #if PY_MAJOR_VERSION >= 3
@@ -51,7 +52,7 @@ typedef struct {
     PyObject *root;
     PyObject *decoded_objects;
     PyObject *allow_multiple_values;
-
+    yajl_handle parser;
 } _YajlDecoder;
 
 typedef struct {
@@ -90,10 +91,11 @@ enum { failure, success };
 /*
  * Methods defined for the YajlDecoder type in decoder.c
  */
-extern PyObject *py_yajldecoder_decode(PYARGS);
-extern int yajldecoder_init(PYARGS);
+extern PyObject *py_yajldecoder_decode(PyObject *self, PyObject *args);
+extern int yajldecoder_init(PyObject *self, PyObject *args, PyObject *kwargs);
 extern void yajldecoder_dealloc(_YajlDecoder *self);
 extern PyObject *_internal_decode(_YajlDecoder *self, char *buffer, unsigned int buflen);
+extern PyObject *py_yajldecoder_reset(_YajlDecoder *self,PyObject *args);
 extern Py_ssize_t decoder_len(_YajlDecoder *self);
 
 

--- a/py_yajl.h
+++ b/py_yajl.h
@@ -50,6 +50,7 @@ typedef struct {
     py_yajl_bytestack keys;
     PyObject *root;
     PyObject *decoded_objects;
+    PyObject *allow_multiple_values;
 
 } _YajlDecoder;
 

--- a/py_yajl.h
+++ b/py_yajl.h
@@ -102,6 +102,8 @@ extern PyObject *_internal_decode(_YajlDecoder *self, char *buffer, unsigned int
 extern PyObject *py_yajldecoder_reset(_YajlDecoder *self,PyObject *args);
 extern Py_ssize_t decoder_len(_YajlDecoder *self);
 extern PyObject *_fetchObject(_YajlDecoder *self);
+extern PyObject *py_yajldecoder_iter(PyObject *self);
+extern PyObject *py_yajldecoder_iternext(PyObject *self);
 
 
 /*

--- a/py_yajl.h
+++ b/py_yajl.h
@@ -39,6 +39,8 @@
 
 #if PY_MAJOR_VERSION >= 3
 #define IS_PYTHON3
+#define PyString_AsStringAndSize   PyBytes_AsStringAndSize
+#define PyString_Check        PyBytes_Check
 #endif
 
 typedef struct {

--- a/py_yajl.h
+++ b/py_yajl.h
@@ -49,6 +49,7 @@ typedef struct {
     py_yajl_bytestack elements;
     py_yajl_bytestack keys;
     PyObject *root;
+    PyObject *decoded_objects;
 
 } _YajlDecoder;
 

--- a/py_yajl.h
+++ b/py_yajl.h
@@ -94,6 +94,7 @@ extern PyObject *py_yajldecoder_decode(PYARGS);
 extern int yajldecoder_init(PYARGS);
 extern void yajldecoder_dealloc(_YajlDecoder *self);
 extern PyObject *_internal_decode(_YajlDecoder *self, char *buffer, unsigned int buflen);
+extern Py_ssize_t decoder_len(_YajlDecoder *self);
 
 
 /*

--- a/py_yajl.h
+++ b/py_yajl.h
@@ -99,7 +99,7 @@ extern PyObject *py_yajlencoder_encode(PYARGS);
 extern PyObject* py_yajlencoder_default(PYARGS);
 extern int yajlencoder_init(PYARGS);
 extern void yajlencoder_dealloc(_YajlEncoder *self);
-extern PyObject *_internal_encode(_YajlEncoder *self, PyObject *obj, yajl_gen_config config);
+extern PyObject *_internal_encode(_YajlEncoder *self, PyObject *obj, yajl_gen gen);
 
 #endif
 

--- a/py_yajl.h
+++ b/py_yajl.h
@@ -52,7 +52,11 @@ typedef struct {
     PyObject *root;
     PyObject *decoded_objects;
     PyObject *allow_multiple_values;
+    PyObject *stream;
+    PyObject *bufsize;
     yajl_handle parser;
+    
+
 } _YajlDecoder;
 
 typedef struct {
@@ -91,12 +95,13 @@ enum { failure, success };
 /*
  * Methods defined for the YajlDecoder type in decoder.c
  */
-extern PyObject *py_yajldecoder_decode(PyObject *self, PyObject *args);
+extern PyObject *py_yajldecoder_decode(_YajlDecoder *self, PyObject *args);
 extern int yajldecoder_init(PyObject *self, PyObject *args, PyObject *kwargs);
 extern void yajldecoder_dealloc(_YajlDecoder *self);
 extern PyObject *_internal_decode(_YajlDecoder *self, char *buffer, unsigned int buflen);
 extern PyObject *py_yajldecoder_reset(_YajlDecoder *self,PyObject *args);
 extern Py_ssize_t decoder_len(_YajlDecoder *self);
+extern PyObject *_fetchObject(_YajlDecoder *self);
 
 
 /*

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,3 +1,9 @@
 #!/bin/sh
 
-python setup.py build && PYTHONPATH=.:build/lib.linux-x86_64-2.6 python tests/unit.py && zcat test_data/issue_11.gz| PYTHONPATH=build/lib.linux-x86_64-2.6 ./tests/issue_11.py && python3 setup.py build && PYTHONPATH=build/lib.linux-x86_64-3.1 python3 tests/unit.py
+python setup.py build &&
+PYTHONPATH=.:build/lib.linux-x86_64-2.6 python tests/unit.py &&
+zcat test_data/issue_11.gz| PYTHONPATH=build/lib.linux-x86_64-2.6 ./tests/issue_11.py && 
+
+python3 setup.py build && 
+PYTHONPATH=build/lib.linux-x86_64-3.1 python3 tests/unit.py
+zcat test_data/issue_11.gz| PYTHONPATH=build/lib.linux-x86_64-3.1 python3 ./tests/issue_11.py 

--- a/runtests.sh
+++ b/runtests.sh
@@ -5,5 +5,5 @@ PYTHONPATH=.:build/lib.linux-x86_64-2.6 python tests/unit.py &&
 zcat test_data/issue_11.gz| PYTHONPATH=build/lib.linux-x86_64-2.6 ./tests/issue_11.py && 
 
 python3 setup.py build && 
-PYTHONPATH=build/lib.linux-x86_64-3.1 python3 tests/unit.py
+PYTHONPATH=build/lib.linux-x86_64-3.1 python3 tests/unit.py &&
 zcat test_data/issue_11.gz| PYTHONPATH=build/lib.linux-x86_64-3.1 python3 ./tests/issue_11.py 

--- a/tests/issue_11.py
+++ b/tests/issue_11.py
@@ -6,4 +6,3 @@ import sys
 for i, l in enumerate(sys.stdin):
     l = l.rstrip('\n').split('\t')
     d = yajl.dumps(tuple(l))
-    print i,

--- a/tests/python2.py
+++ b/tests/python2.py
@@ -11,3 +11,5 @@ IssueSevenTest_latin1_char = u'f\xe9in'
 IssueSevenTest_chinese_char = u'\u65e9\u5b89, \u7238\u7238'
 
 IssueTwelveTest_dict = {u'a' : u'b', u'c' : u'd'}
+
+IssueTwentySevenTest_dict = u'[{"data":"Podstawow\u0105 opiek\u0119 zdrowotn\u0105"}]'

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -335,10 +335,10 @@ class IssueSixteenTest(unittest.TestCase):
 class IssueTwentySevenTest(unittest.TestCase):
     "https://github.com/rtyler/py-yajl/issues/27"
     def runTest(self):
-        u = u'[{"data":"Podstawow\u0105 opiek\u0119 zdrowotn\u0105"}]'
-        self.assertEqual(
-                yajl.dumps(yajl.loads(u)),
-                '[{"data":"Podstawow\\u0105 opiek\\u0119 zdrowotn\\u0105"}]')
+        if not is_python3():
+            from tests import python2
+            self.assertEqual(yajl.dumps(yajl.loads(python2.IssueTwentySevenTest_dict)),
+                            '[{"data":"Podstawow\\u0105 opiek\\u0119 zdrowotn\\u0105"}]')
 
 
 if __name__ == '__main__':

--- a/yajl.c
+++ b/yajl.c
@@ -193,6 +193,9 @@ static PyObject *py_loads(PYARGS)
 
     result = _internal_decode(
             (_YajlDecoder *)decoder, buffer, (unsigned int)buflen);
+    if (result != NULL) {
+        result = _fetchObject((_YajlDecoder *)decoder);
+    }    
     Py_DECREF(pybuffer);
     Py_XDECREF(decoder);
     return result;
@@ -315,6 +318,9 @@ static PyObject *_internal_stream_load(PyObject *args, unsigned int blocking)
     result = _internal_decode((_YajlDecoder *)decoder, PyString_AsString(buffer),
                   PyString_Size(buffer));
 #endif
+    if (result != NULL) {
+        result = _fetchObject((_YajlDecoder *)decoder);
+    }
     Py_XDECREF(decoder);
     Py_XDECREF(buffer);
     return result;

--- a/yajl.c
+++ b/yajl.c
@@ -47,6 +47,18 @@ static PyMethodDef yajlencoder_methods[] = {
     {NULL}
 };
 
+static PySequenceMethods decoder_as_sequence = {
+    (lenfunc)decoder_len,               /* sq_length */
+    0,                                  /* sq_concat */
+    0,                                  /* sq_repeat */
+    0,                                  /* sq_item */
+    0,                                  /* sq_slice */
+    0,                                  /* sq_ass_item */
+    0,                                  /* sq_ass_slice */
+    0,                                  /* sq_contains */
+};
+
+
 static PyTypeObject YajlDecoderType = {
 #ifdef IS_PYTHON3
     PyVarObject_HEAD_INIT(NULL, 0)
@@ -64,7 +76,7 @@ static PyTypeObject YajlDecoderType = {
     0,                         /*tp_compare*/
     0,                         /*tp_repr*/
     0,                         /*tp_as_number*/
-    0,                         /*tp_as_sequence*/
+    &decoder_as_sequence,      /*tp_as_sequence*/
     0,                         /*tp_as_mapping*/
     0,                         /*tp_hash */
     0,                         /*tp_call*/

--- a/yajl.c
+++ b/yajl.c
@@ -38,6 +38,7 @@ static PyObject *empty_tuple;
 
 static PyMethodDef yajldecoder_methods[] = {
     {"decode", (PyCFunction)(py_yajldecoder_decode), METH_VARARGS, NULL},
+    {"reset",  (PyCFunction)(py_yajldecoder_reset), METH_VARARGS, NULL},
     {NULL}
 };
 

--- a/yajl.c
+++ b/yajl.c
@@ -328,10 +328,6 @@ static PyObject *py_load(PYARGS)
 {
     return _internal_stream_load(args, 1);
 }
-static PyObject *py_iterload(PYARGS)
-{
-    return _internal_stream_load(args, 0);
-}
 
 static PyObject *__write = NULL;
 static PyObject *_internal_stream_dump(PyObject *object, PyObject *stream, unsigned int blocking,
@@ -408,7 +404,7 @@ static PyObject *py_monkeypatch(PYARGS)
 }
 
 static struct PyMethodDef yajl_methods[] = {
-    {"dumps", (PyCFunctionWithKeywords)(py_dumps), METH_VARARGS | METH_KEYWORDS,
+    {"dumps", (PyCFunction)(py_dumps), METH_VARARGS | METH_KEYWORDS,
 "yajl.dumps(obj [, indent=None])\n\n\
 Returns an encoded JSON string of the specified `obj`\n\
 \n\
@@ -424,7 +420,7 @@ Returns a decoded object based on the given JSON `string`"},
 "yajl.load(fp)\n\n\
 Returns a decoded object based on the JSON read from the `fp` stream-like\n\
 object; *Note:* It is expected that `fp` supports the `read()` method"},
-    {"dump", (PyCFunctionWithKeywords)(py_dump), METH_VARARGS | METH_KEYWORDS,
+    {"dump", (PyCFunction)(py_dump), METH_VARARGS | METH_KEYWORDS,
 "yajl.dump(obj, fp [, indent=None])\n\n\
 Encodes the given `obj` and writes it to the `fp` stream-like object. \n\
 *Note*: It is expected that `fp` supports the `write()` method\n\
@@ -434,9 +430,6 @@ and object members will be pretty-printed with that indent level. \n\
 An indent level of 0 will only insert newlines. None (the default) \n\
 selects the most compact representation.\n\
 "},
-    /*
-     {"iterload", (PyCFunction)(py_iterload), METH_VARARGS, NULL},
-     */
     {"monkeypatch", (PyCFunction)(py_monkeypatch), METH_NOARGS,
 "yajl.monkeypatch()\n\n\
 Monkey-patches the yajl module into sys.modules as \"json\"\n\

--- a/yajl.c
+++ b/yajl.c
@@ -316,8 +316,9 @@ static PyObject *_internal_stream_dump(PyObject *object, PyObject *stream, unsig
 
     buffer = _internal_encode((_YajlEncoder *)encoder, object, gen);
     PyObject_CallMethodObjArgs(stream, __write, buffer, NULL);
+    Py_XDECREF(buffer);
     Py_XDECREF(encoder);
-    return Py_True;
+    Py_RETURN_TRUE;
 
 bad_type:
     PyErr_SetObject(PyExc_TypeError, PyUnicode_FromString("Must pass a stream object"));
@@ -357,7 +358,7 @@ static PyObject *py_monkeypatch(PYARGS)
     PyObject *yajl = PyDict_GetItemString(modules, "yajl");
 
     if (!yajl) {
-        return Py_False;
+        Py_RETURN_FALSE;
     }
 
     PyDict_SetItemString(modules, "json_old", PyDict_GetItemString(modules, "json"));
@@ -365,7 +366,7 @@ static PyObject *py_monkeypatch(PYARGS)
 
     Py_XDECREF(sys);
     Py_XDECREF(modules);
-    return Py_True;
+    Py_RETURN_TRUE;
 }
 
 static struct PyMethodDef yajl_methods[] = {

--- a/yajl.c
+++ b/yajl.c
@@ -33,6 +33,9 @@
 
 #include "py_yajl.h"
 
+/* As the name says, an empty tuple. */
+static PyObject *empty_tuple;
+
 static PyMethodDef yajldecoder_methods[] = {
     {"decode", (PyCFunction)(py_yajldecoder_decode), METH_VARARGS, NULL},
     {NULL}
@@ -170,7 +173,7 @@ static PyObject *py_loads(PYARGS)
         return NULL;
     }
 
-    decoder = PyObject_Call((PyObject *)(&YajlDecoderType), NULL, NULL);
+    decoder = PyObject_CallObject((PyObject *)(&YajlDecoderType), empty_tuple);
     if (decoder == NULL) {
         return NULL;
     }
@@ -286,7 +289,7 @@ static PyObject *_internal_stream_load(PyObject *args, unsigned int blocking)
         return NULL;
 #endif
 
-    decoder = PyObject_Call((PyObject *)(&YajlDecoderType), NULL, NULL);
+    decoder = PyObject_CallObject((PyObject *)(&YajlDecoderType), empty_tuple);
     if (decoder == NULL) {
         return NULL;
     }

--- a/yajl.c
+++ b/yajl.c
@@ -392,7 +392,7 @@ static PyObject *py_monkeypatch(PYARGS)
 }
 
 static struct PyMethodDef yajl_methods[] = {
-    {"dumps", (PyCFunctionWithKeywords)py_dumps, METH_VARARGS | METH_KEYWORDS,
+    {"dumps", (PyCFunctionWithKeywords)(py_dumps), METH_VARARGS | METH_KEYWORDS,
 "yajl.dumps(obj [, indent=None])\n\n\
 Returns an encoded JSON string of the specified `obj`\n\
 \n\


### PR DESCRIPTION
Note: I've aimed to keep backwards API compatibility but I've made some additions, how these new additions actually work are open to discussion.

I think that this patch aims to address issues:
- #1 - Make more awesome
- #14 - Steal stream ideas from yajl-ruby
- #31 - Undefined symbols in python 3.2 
- #32 - Memory leak when dumps()'ing large objects

The main improvement is that you can now write something like:

```
import yajl
import sys

for i in yajl.Decoder(allow_multiple_values=True,stream=sys.stdin):
    print i
```

Which will let you iterate over a stream of json objects read from the processes std input channel. It's not too slow either, on my core2duo a yajl based producer / consumer connected via a unix pipe with a very basic object can process about 100,000 json objects/sec.

I don't think the iterator method will handle non blocking sockets very well at the moment, it may not handle them at all - I've not tested it yet. If the file object is in blocking mode the iterator handles that fine.

I've also fixed a number of bugs relating to memory management (including issue #32) along the way.

Summary of changes.
- Maintain backwards compatibility
- Upgrade to newer version of yajl
- Change yajl decoder class to decode objects into an internal python list (as each read while iterating my decode 0 to >1 objects yet we must only return 1).
- Add iterator method to decoder
- Add len() method to the decoder (though I'm not really sure if this is needed - it returns the size of the internal list).
- decoder now takes 3 optional arguments when being initialised.
  1. allow_multiple_values - true / false - allow yajl to continue decoding past the first value
  2. stream - a file like object to read from when iterating -
  3. bufsize - integer - the size of each read performed internally when iterating over a stream

The unit tests still pass and the current version also supports python 3. Though I really should write some more unit tests for the new features and some documentation to accompany them.
