### PR TITLE
memory leak fixes

### DIFF
--- a/encoder.c
+++ b/encoder.c
@@ -142,7 +142,9 @@ static yajl_gen_status ProcessObject(_YajlEncoder *self, PyObject *object)
             }
         }
         buffer[offset] = '\0';
-        return yajl_gen_raw_string(handle, (const unsigned char *)(buffer), (unsigned int)(offset));
+        status = yajl_gen_raw_string(handle, (const unsigned char *)(buffer), (unsigned int)(offset));
+        free(buffer);
+        return status;
     }
 #ifdef IS_PYTHON3
     if (PyBytes_Check(object)) {
@@ -238,6 +240,9 @@ static yajl_gen_status ProcessObject(_YajlEncoder *self, PyObject *object)
             }
 
             status = ProcessObject(self, newKey);
+            if (key != newKey) {
+                Py_XDECREF(newKey);
+            }
             if (status == yajl_gen_in_error_state) return status;
             if (status == yajl_max_depth_exceeded) goto exit;
 

--- a/yajl.c
+++ b/yajl.c
@@ -339,6 +339,7 @@ static PyObject *_internal_stream_dump(PyObject *object, PyObject *stream, unsig
     buffer = _internal_encode((_YajlEncoder *)encoder, object, config);
     PyObject_CallMethodObjArgs(stream, __write, buffer, NULL);
     Py_XDECREF(encoder);
+    Py_XDECREF(buffer);
     return Py_True;
 
 bad_type:


### PR DESCRIPTION
Fixes for two fairly significant leaks I found with the help of valgrind. The `ProcessObject` patch may fix issue #32, although that issue refers to `dumps()` and in my testing `dump()` was the primary source of leaked memory.
