### PR TITLE
Update iainb's pull request to merge cleanly + socket support + decode a buffer at a time + bugfixes

### DIFF
--- a/BUILDING.markdown
+++ b/BUILDING.markdown
@@ -4,5 +4,5 @@ Getting started building py-yajl
 1. clone this repository
 2. `git submodule update --init`
 3. `python setup.py build_ext --inplace`
-4. `python tests.py`
+4. `runtests.sh`
 

--- a/decoder.c
+++ b/decoder.c
@@ -391,8 +391,6 @@ PyObject *py_yajldecoder_iternext(PyObject *self)
         }
 #endif
 
-        Py_INCREF(buffer);
-
 #ifdef IS_PYTHON3
         result = _internal_decode((_YajlDecoder *)d, PyBytes_AsString(bufferstring),
                   PyBytes_Size(bufferstring));

--- a/decoder.c
+++ b/decoder.c
@@ -323,8 +323,12 @@ PyObject *py_yajldecoder_iterdecode(_YajlDecoder *self, PyObject *args)
     }
 
     Py_DECREF(pybuffer);
+    Py_INCREF(self->decoded_objects);
     result = self->decoded_objects;
-    self->decoded_objects = PyList_New(0);
+    if (PySequence_Size(self->decoded_objects) > 0) {
+        Py_DECREF(self->decoded_objects);
+        self->decoded_objects = PyList_New(0);
+    }
     return result;
 }
 

--- a/decoder.c
+++ b/decoder.c
@@ -493,9 +493,11 @@ int yajldecoder_init(PyObject *self, PyObject *args, PyObject *kwargs)
     py_yajl_ps_init(me->keys); 
 
     // stream setup
-    if (!PyObject_HasAttrString(stream,"read")) {
-        PyErr_SetObject(PyExc_TypeError, PyUnicode_FromString("stream object must have a read attribute"));
-        return -1;
+    if (stream) {
+        if (!PyObject_HasAttrString(stream,"read")) {
+            PyErr_SetObject(PyExc_TypeError, PyUnicode_FromString("stream object must have a read attribute"));
+            return -1;
+        }
     }
 
     me->stream = stream;

--- a/decoder.c
+++ b/decoder.c
@@ -493,6 +493,11 @@ int yajldecoder_init(PyObject *self, PyObject *args, PyObject *kwargs)
     py_yajl_ps_init(me->keys); 
 
     // stream setup
+    if (!PyObject_HasAttrString(stream,"read")) {
+        PyErr_SetObject(PyExc_TypeError, PyUnicode_FromString("stream object must have a read attribute"));
+        return -1;
+    }
+
     me->stream = stream;
     if (bufsize) {
 #ifdef IS_PYTHON3

--- a/decoder.c
+++ b/decoder.c
@@ -574,6 +574,7 @@ int yajldecoder_init(PyObject *self, PyObject *args, PyObject *kwargs)
             PyErr_SetObject(PyExc_TypeError, PyUnicode_FromString("bufsize must be >= 1"));
             return -1;
         }
+        Py_INCREF(bufsize);
         me->bufsize = bufsize;
     } else {
 #ifdef IS_PYTHON3

--- a/decoder.c
+++ b/decoder.c
@@ -249,9 +249,7 @@ PyObject *_internal_decode(_YajlDecoder *self, char *buffer, unsigned int buflen
                 PyUnicode_FromString(yajl_status_to_string(yrc)));
         return NULL;
     }
-
-    Py_INCREF(Py_None);
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 /*
@@ -442,8 +440,7 @@ PyObject *py_yajldecoder_reset(_YajlDecoder *self,PyObject *args)
         yajl_config(self->parser,yajl_allow_multiple_values,1);
     }
 
-    Py_INCREF(Py_None);
-    return Py_None;
+    Py_RETURN_NONE;
 }
 
 /*
@@ -480,6 +477,7 @@ int yajldecoder_init(PyObject *self, PyObject *args, PyObject *kwargs)
         }
     } else {
         // default to false
+        Py_INCREF(Py_False);
         allow_multiple_values = Py_False;
     }
 

--- a/decoder.c
+++ b/decoder.c
@@ -337,6 +337,11 @@ PyObject *py_yajldecoder_decode(PYARGS)
     return result;
 }
 
+Py_ssize_t decoder_len(_YajlDecoder *self)
+{
+    return PySequence_Size(self->decoded_objects);
+}
+
 int yajldecoder_init(PYARGS)
 {
     PyObject *allow_multiple_values = NULL;

--- a/decoder.c
+++ b/decoder.c
@@ -258,6 +258,7 @@ PyObject *_internal_decode(_YajlDecoder *self, char *buffer, unsigned int buflen
     yrc = yajl_parse(parser, (const unsigned char *)(buffer), buflen);
 
     if (yrc != yajl_status_ok) {
+        yajl_free(parser);
         PyErr_SetObject(PyExc_ValueError,
                 PyUnicode_FromString(yajl_status_to_string(yrc)));
         return NULL;

--- a/decoder.c
+++ b/decoder.c
@@ -507,13 +507,14 @@ int yajldecoder_init(PyObject *self, PyObject *args, PyObject *kwargs)
             return -1;
         }
 #ifdef IS_PYTHON3
-        if (PyLong_AsLong(bufsize) < 1) {
+        if (!(PyLong_AsLong(bufsize) >= 1)) {
 #else
-        if (!PyInt_Check(bufsize) < 1) {
+        if (!(PyInt_AsLong(bufsize) >=  1)) {
 #endif
-            PyErr_SetObject(PyExc_TypeError, PyUnicode_FromString("bufsize must be > 1"));
+            PyErr_SetObject(PyExc_TypeError, PyUnicode_FromString("bufsize must be >= 1"));
             return -1;
         }
+        me->bufsize = bufsize;
     } else {
 #ifdef IS_PYTHON3
         me->bufsize = PyLong_FromLong(512);

--- a/encoder.c
+++ b/encoder.c
@@ -142,7 +142,7 @@ static yajl_gen_status ProcessObject(_YajlEncoder *self, PyObject *object)
             }
         }
         buffer[offset] = '\0';
-        status = yajl_gen_raw_string(handle, (const unsigned char *)(buffer), (unsigned int)(offset));
+        status = yajl_gen_raw_string(handle, (const char *)(buffer), (unsigned int)(offset));
         free(buffer);
         return status;
     }

--- a/encoder.c
+++ b/encoder.c
@@ -42,7 +42,7 @@ static const char *hexdigit = "0123456789abcdef";
 
 /* Located in yajl_hacks.c */
 extern yajl_gen_status yajl_gen_raw_string(yajl_gen g,
-        const unsigned char * str, unsigned int len);
+        const char * str, unsigned int len);
 
 static yajl_gen_status ProcessObject(_YajlEncoder *self, PyObject *object)
 {
@@ -326,9 +326,8 @@ static PyObject * lowLevelStringAlloc(Py_ssize_t size)
     return (PyObject *) op;
 }
 
-PyObject *_internal_encode(_YajlEncoder *self, PyObject *obj, yajl_gen_config genconfig)
+PyObject *_internal_encode(_YajlEncoder *self, PyObject *obj, yajl_gen gen)
 {
-    yajl_gen generator = NULL;
     yajl_gen_status status;
     struct StringAndUsedCount sauc;
 #ifdef IS_PYTHON3
@@ -341,13 +340,13 @@ PyObject *_internal_encode(_YajlEncoder *self, PyObject *obj, yajl_gen_config ge
     sauc.used = 0;
     sauc.str = lowLevelStringAlloc(PY_YAJL_CHUNK_SZ);
 
-    generator = yajl_gen_alloc2(py_yajl_printer, &genconfig, NULL, (void *) &sauc);
+    yajl_gen_config(gen,yajl_gen_print_callback,py_yajl_printer,(void *) &sauc);
 
-    self->_generator = generator;
+    self->_generator = gen;
 
     status = ProcessObject(self, obj);
 
-    yajl_gen_free(generator);
+    yajl_gen_free(gen);
     self->_generator = NULL;
 
     /* if resize failed inside our printer function we'll have a null sauc.str */
@@ -392,12 +391,13 @@ PyObject *py_yajlencoder_default(PYARGS)
 PyObject *py_yajlencoder_encode(PYARGS)
 {
     _YajlEncoder *encoder = (_YajlEncoder *)(self);
-    yajl_gen_config config = {0, NULL};
+    yajl_gen gen;
+    gen = yajl_gen_alloc(NULL);
     PyObject *value;
 
     if (!PyArg_ParseTuple(args, "O", &value))
         return NULL;
-    return _internal_encode(encoder, value, config);
+    return _internal_encode(encoder, value, gen);
 }
 
 int yajlencoder_init(PYARGS)

--- a/encoder.c
+++ b/encoder.c
@@ -313,12 +313,12 @@ static PyObject * lowLevelStringAlloc(Py_ssize_t size)
 #ifdef IS_PYTHON3
     PyBytesObject * op = (PyBytesObject *)PyObject_MALLOC(sizeof(PyBytesObject) + size);
     if (op) {
-        PyObject_INIT_VAR(op, &PyBytes_Type, size);
+        (void) PyObject_INIT_VAR(op, &PyBytes_Type, size);
     }
 #else
     PyStringObject * op = (PyStringObject *)PyObject_MALLOC(sizeof(PyStringObject) + size);
     if (op) {
-        PyObject_INIT_VAR(op, &PyString_Type, size);
+        (void) PyObject_INIT_VAR(op, &PyString_Type, size);
         op->ob_shash = -1;
         op->ob_sstate = SSTATE_NOT_INTERNED;
     }

--- a/py_yajl.h
+++ b/py_yajl.h
@@ -35,6 +35,7 @@
 
 #include <Python.h>
 #include <yajl/yajl_gen.h>
+#include <yajl/yajl_parse.h>
 #include "ptrstack.h"
 
 #if PY_MAJOR_VERSION >= 3
@@ -51,7 +52,7 @@ typedef struct {
     PyObject *root;
     PyObject *decoded_objects;
     PyObject *allow_multiple_values;
-
+    yajl_handle parser;
 } _YajlDecoder;
 
 typedef struct {
@@ -90,10 +91,11 @@ enum { failure, success };
 /*
  * Methods defined for the YajlDecoder type in decoder.c
  */
-extern PyObject *py_yajldecoder_decode(PYARGS);
-extern int yajldecoder_init(PYARGS);
+extern PyObject *py_yajldecoder_decode(PyObject *self, PyObject *args);
+extern int yajldecoder_init(PyObject *self, PyObject *args, PyObject *kwargs);
 extern void yajldecoder_dealloc(_YajlDecoder *self);
 extern PyObject *_internal_decode(_YajlDecoder *self, char *buffer, unsigned int buflen);
+extern PyObject *py_yajldecoder_reset(_YajlDecoder *self,PyObject *args);
 extern Py_ssize_t decoder_len(_YajlDecoder *self);
 
 

--- a/py_yajl.h
+++ b/py_yajl.h
@@ -50,6 +50,7 @@ typedef struct {
     py_yajl_bytestack keys;
     PyObject *root;
     PyObject *decoded_objects;
+    PyObject *allow_multiple_values;
 
 } _YajlDecoder;
 

--- a/py_yajl.h
+++ b/py_yajl.h
@@ -102,6 +102,8 @@ extern PyObject *_internal_decode(_YajlDecoder *self, char *buffer, unsigned int
 extern PyObject *py_yajldecoder_reset(_YajlDecoder *self,PyObject *args);
 extern Py_ssize_t decoder_len(_YajlDecoder *self);
 extern PyObject *_fetchObject(_YajlDecoder *self);
+extern PyObject *py_yajldecoder_iter(PyObject *self);
+extern PyObject *py_yajldecoder_iternext(PyObject *self);
 
 
 /*

--- a/py_yajl.h
+++ b/py_yajl.h
@@ -101,7 +101,7 @@ extern PyObject *py_yajlencoder_encode(PYARGS);
 extern PyObject* py_yajlencoder_default(PYARGS);
 extern int yajlencoder_init(PYARGS);
 extern void yajlencoder_dealloc(_YajlEncoder *self);
-extern PyObject *_internal_encode(_YajlEncoder *self, PyObject *obj, yajl_gen_config config);
+extern PyObject *_internal_encode(_YajlEncoder *self, PyObject *obj, yajl_gen gen);
 
 #endif
 

--- a/py_yajl.h
+++ b/py_yajl.h
@@ -49,6 +49,7 @@ typedef struct {
     py_yajl_bytestack elements;
     py_yajl_bytestack keys;
     PyObject *root;
+    PyObject *decoded_objects;
 
 } _YajlDecoder;
 

--- a/py_yajl.h
+++ b/py_yajl.h
@@ -39,8 +39,8 @@
 
 #if PY_MAJOR_VERSION >= 3
 #define IS_PYTHON3
-#define PyString_AsStringAndSize 	PyBytes_AsStringAndSize
-#define PyString_Check				PyBytes_Check
+#define PyString_AsStringAndSize   PyBytes_AsStringAndSize
+#define PyString_Check        PyBytes_Check
 #endif
 
 typedef struct {

--- a/py_yajl.h
+++ b/py_yajl.h
@@ -94,6 +94,7 @@ extern PyObject *py_yajldecoder_decode(PYARGS);
 extern int yajldecoder_init(PYARGS);
 extern void yajldecoder_dealloc(_YajlDecoder *self);
 extern PyObject *_internal_decode(_YajlDecoder *self, char *buffer, unsigned int buflen);
+extern Py_ssize_t decoder_len(_YajlDecoder *self);
 
 
 /*

--- a/py_yajl.h
+++ b/py_yajl.h
@@ -40,8 +40,8 @@
 
 #if PY_MAJOR_VERSION >= 3
 #define IS_PYTHON3
-#define PyString_AsStringAndSize   PyBytes_AsStringAndSize
-#define PyString_Check        PyBytes_Check
+#define PyString_AsStringAndSize	PyBytes_AsStringAndSize
+#define PyString_Check				PyBytes_Check
 #endif
 
 typedef struct {
@@ -104,6 +104,7 @@ extern Py_ssize_t decoder_len(_YajlDecoder *self);
 extern PyObject *_fetchObject(_YajlDecoder *self);
 extern PyObject *py_yajldecoder_iter(PyObject *self);
 extern PyObject *py_yajldecoder_iternext(PyObject *self);
+extern PyObject *py_yajldecoder_iterdecode(_YajlDecoder *self, PyObject *args);
 
 
 /*

--- a/py_yajl.h
+++ b/py_yajl.h
@@ -52,7 +52,11 @@ typedef struct {
     PyObject *root;
     PyObject *decoded_objects;
     PyObject *allow_multiple_values;
+    PyObject *stream;
+    PyObject *bufsize;
     yajl_handle parser;
+    
+
 } _YajlDecoder;
 
 typedef struct {
@@ -91,12 +95,13 @@ enum { failure, success };
 /*
  * Methods defined for the YajlDecoder type in decoder.c
  */
-extern PyObject *py_yajldecoder_decode(PyObject *self, PyObject *args);
+extern PyObject *py_yajldecoder_decode(_YajlDecoder *self, PyObject *args);
 extern int yajldecoder_init(PyObject *self, PyObject *args, PyObject *kwargs);
 extern void yajldecoder_dealloc(_YajlDecoder *self);
 extern PyObject *_internal_decode(_YajlDecoder *self, char *buffer, unsigned int buflen);
 extern PyObject *py_yajldecoder_reset(_YajlDecoder *self,PyObject *args);
 extern Py_ssize_t decoder_len(_YajlDecoder *self);
+extern PyObject *_fetchObject(_YajlDecoder *self);
 
 
 /*

--- a/py_yajl.h
+++ b/py_yajl.h
@@ -55,7 +55,7 @@ typedef struct {
     PyObject *stream;
     PyObject *bufsize;
     yajl_handle parser;
-    
+    char *read_fn;
 
 } _YajlDecoder;
 

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,3 +1,9 @@
 #!/bin/sh
 
-python setup.py build && PYTHONPATH=.:build/lib.linux-x86_64-2.6 python tests/unit.py && zcat test_data/issue_11.gz| PYTHONPATH=build/lib.linux-x86_64-2.6 ./tests/issue_11.py && python3 setup.py build && PYTHONPATH=build/lib.linux-x86_64-3.1 python3 tests/unit.py
+python setup.py build &&
+PYTHONPATH=.:build/lib.linux-x86_64-2.6 python tests/unit.py &&
+zcat test_data/issue_11.gz| PYTHONPATH=build/lib.linux-x86_64-2.6 ./tests/issue_11.py && 
+
+python3 setup.py build && 
+PYTHONPATH=build/lib.linux-x86_64-3.1 python3 tests/unit.py
+zcat test_data/issue_11.gz| PYTHONPATH=build/lib.linux-x86_64-3.1 python3 ./tests/issue_11.py 

--- a/runtests.sh
+++ b/runtests.sh
@@ -5,5 +5,5 @@ PYTHONPATH=.:build/lib.linux-x86_64-2.6 python tests/unit.py &&
 zcat test_data/issue_11.gz| PYTHONPATH=build/lib.linux-x86_64-2.6 ./tests/issue_11.py && 
 
 python3 setup.py build && 
-PYTHONPATH=build/lib.linux-x86_64-3.1 python3 tests/unit.py
+PYTHONPATH=build/lib.linux-x86_64-3.1 python3 tests/unit.py &&
 zcat test_data/issue_11.gz| PYTHONPATH=build/lib.linux-x86_64-3.1 python3 ./tests/issue_11.py 

--- a/tests/issue_11.py
+++ b/tests/issue_11.py
@@ -6,4 +6,3 @@ import sys
 for i, l in enumerate(sys.stdin):
     l = l.rstrip('\n').split('\t')
     d = yajl.dumps(tuple(l))
-    print i,

--- a/tests/python2.py
+++ b/tests/python2.py
@@ -11,3 +11,5 @@ IssueSevenTest_latin1_char = u'f\xe9in'
 IssueSevenTest_chinese_char = u'\u65e9\u5b89, \u7238\u7238'
 
 IssueTwelveTest_dict = {u'a' : u'b', u'c' : u'd'}
+
+IssueTwentySevenTest_dict = u'[{"data":"Podstawow\u0105 opiek\u0119 zdrowotn\u0105"}]'

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -335,10 +335,10 @@ class IssueSixteenTest(unittest.TestCase):
 class IssueTwentySevenTest(unittest.TestCase):
     "https://github.com/rtyler/py-yajl/issues/27"
     def runTest(self):
-        u = u'[{"data":"Podstawow\u0105 opiek\u0119 zdrowotn\u0105"}]'
-        self.assertEqual(
-                yajl.dumps(yajl.loads(u)),
-                '[{"data":"Podstawow\\u0105 opiek\\u0119 zdrowotn\\u0105"}]')
+        if not is_python3():
+            from tests import python2
+            self.assertEqual(yajl.dumps(yajl.loads(python2.IssueTwentySevenTest_dict)),
+                            '[{"data":"Podstawow\\u0105 opiek\\u0119 zdrowotn\\u0105"}]')
 
 
 if __name__ == '__main__':

--- a/yajl.c
+++ b/yajl.c
@@ -193,6 +193,9 @@ static PyObject *py_loads(PYARGS)
 
     result = _internal_decode(
             (_YajlDecoder *)decoder, buffer, (unsigned int)buflen);
+    if (result != NULL) {
+        result = _fetchObject((_YajlDecoder *)decoder);
+    }    
     Py_DECREF(pybuffer);
     Py_XDECREF(decoder);
     return result;
@@ -315,6 +318,9 @@ static PyObject *_internal_stream_load(PyObject *args, unsigned int blocking)
     result = _internal_decode((_YajlDecoder *)decoder, PyString_AsString(buffer),
                   PyString_Size(buffer));
 #endif
+    if (result != NULL) {
+        result = _fetchObject((_YajlDecoder *)decoder);
+    }
     Py_XDECREF(decoder);
     Py_XDECREF(buffer);
     return result;

--- a/yajl.c
+++ b/yajl.c
@@ -47,6 +47,18 @@ static PyMethodDef yajlencoder_methods[] = {
     {NULL}
 };
 
+static PySequenceMethods decoder_as_sequence = {
+    (lenfunc)decoder_len,               /* sq_length */
+    0,                                  /* sq_concat */
+    0,                                  /* sq_repeat */
+    0,                                  /* sq_item */
+    0,                                  /* sq_slice */
+    0,                                  /* sq_ass_item */
+    0,                                  /* sq_ass_slice */
+    0,                                  /* sq_contains */
+};
+
+
 static PyTypeObject YajlDecoderType = {
 #ifdef IS_PYTHON3
     PyVarObject_HEAD_INIT(NULL, 0)
@@ -64,7 +76,7 @@ static PyTypeObject YajlDecoderType = {
     0,                         /*tp_compare*/
     0,                         /*tp_repr*/
     0,                         /*tp_as_number*/
-    0,                         /*tp_as_sequence*/
+    &decoder_as_sequence,      /*tp_as_sequence*/
     0,                         /*tp_as_mapping*/
     0,                         /*tp_hash */
     0,                         /*tp_call*/

--- a/yajl.c
+++ b/yajl.c
@@ -38,6 +38,7 @@ static PyObject *empty_tuple;
 
 static PyMethodDef yajldecoder_methods[] = {
     {"decode", (PyCFunction)(py_yajldecoder_decode), METH_VARARGS, NULL},
+    {"reset",  (PyCFunction)(py_yajldecoder_reset), METH_VARARGS, NULL},
     {NULL}
 };
 

--- a/yajl.c
+++ b/yajl.c
@@ -393,7 +393,7 @@ static PyObject *py_monkeypatch(PYARGS)
 }
 
 static struct PyMethodDef yajl_methods[] = {
-    {"dumps", (PyCFunctionWithKeywords)py_dumps, METH_VARARGS | METH_KEYWORDS,
+    {"dumps", (PyCFunctionWithKeywords)(py_dumps), METH_VARARGS | METH_KEYWORDS,
 "yajl.dumps(obj [, indent=None])\n\n\
 Returns an encoded JSON string of the specified `obj`\n\
 \n\

--- a/yajl.c
+++ b/yajl.c
@@ -318,7 +318,7 @@ static PyObject *_internal_stream_dump(PyObject *object, PyObject *stream, unsig
     PyObject_CallMethodObjArgs(stream, __write, buffer, NULL);
     Py_XDECREF(encoder);
     Py_XDECREF(buffer);
-    return Py_True;
+    Py_RETURN_TRUE;
 
 bad_type:
     PyErr_SetObject(PyExc_TypeError, PyUnicode_FromString("Must pass a stream object"));
@@ -358,7 +358,7 @@ static PyObject *py_monkeypatch(PYARGS)
     PyObject *yajl = PyDict_GetItemString(modules, "yajl");
 
     if (!yajl) {
-        return Py_False;
+        Py_RETURN_FALSE;
     }
 
     PyDict_SetItemString(modules, "json_old", PyDict_GetItemString(modules, "json"));
@@ -366,7 +366,7 @@ static PyObject *py_monkeypatch(PYARGS)
 
     Py_XDECREF(sys);
     Py_XDECREF(modules);
-    return Py_True;
+    Py_RETURN_TRUE;
 }
 
 static struct PyMethodDef yajl_methods[] = {

--- a/yajl.c
+++ b/yajl.c
@@ -182,7 +182,7 @@ static PyObject *py_loads(PYARGS)
     return result;
 }
 
-static char *__config_gen_config(PyObject *indent, yajl_gen_config *config)
+static char *__config_gen_config(PyObject *indent, yajl_gen *config)
 {
     long indentLevel = -1;
     char *spaces = NULL;
@@ -204,15 +204,15 @@ static char *__config_gen_config(PyObject *indent, yajl_gen_config *config)
         indentLevel = PyLong_AsLong(indent);
 
         if (indentLevel >= 0) {
-            config->beautify = 1;
+            yajl_gen_config(*config,yajl_gen_beautify, 1);
             if (indentLevel == 0) {
-                config->indentString = "";
+                yajl_gen_config(*config, yajl_gen_indent_string, "");
             }
             else {
                 spaces = (char *)(malloc(sizeof(char) * (indentLevel + 1)));
                 memset((void *)(spaces), (int)' ', indentLevel);
                 spaces[indentLevel] = '\0';
-                config->indentString = spaces;
+                yajl_gen_config(*config, yajl_gen_indent_string,spaces);
             }
         }
     }
@@ -225,7 +225,7 @@ static PyObject *py_dumps(PYARGS)
     PyObject *obj = NULL;
     PyObject *result = NULL;
     PyObject *indent = NULL;
-    yajl_gen_config config = { 0, NULL };
+    yajl_gen gen;
     static char *kwlist[] = {"object", "indent", NULL};
     char *spaces = NULL;
 
@@ -233,7 +233,8 @@ static PyObject *py_dumps(PYARGS)
         return NULL;
     }
 
-    spaces = __config_gen_config(indent, &config);
+    gen = yajl_gen_alloc(NULL);
+    spaces = __config_gen_config(indent, &gen);
     if (PyErr_Occurred()) {
         return NULL;
     }
@@ -243,7 +244,7 @@ static PyObject *py_dumps(PYARGS)
         return NULL;
     }
 
-    result = _internal_encode((_YajlEncoder *)encoder, obj, config);
+    result = _internal_encode((_YajlEncoder *)encoder, obj, gen);
     Py_XDECREF(encoder);
     if (spaces) {
         free(spaces);
@@ -318,7 +319,7 @@ static PyObject *py_iterload(PYARGS)
 
 static PyObject *__write = NULL;
 static PyObject *_internal_stream_dump(PyObject *object, PyObject *stream, unsigned int blocking,
-            yajl_gen_config config)
+            yajl_gen gen)
 {
     PyObject *encoder = NULL;
     PyObject *buffer = NULL;
@@ -336,7 +337,7 @@ static PyObject *_internal_stream_dump(PyObject *object, PyObject *stream, unsig
         return NULL;
     }
 
-    buffer = _internal_encode((_YajlEncoder *)encoder, object, config);
+    buffer = _internal_encode((_YajlEncoder *)encoder, object, gen);
     PyObject_CallMethodObjArgs(stream, __write, buffer, NULL);
     Py_XDECREF(encoder);
     Py_XDECREF(buffer);
@@ -353,7 +354,7 @@ static PyObject *py_dump(PYARGS)
     PyObject *indent = NULL;
     PyObject *stream = NULL;
     PyObject *result = NULL;
-    yajl_gen_config config = { 0, NULL };
+    yajl_gen gen;
     static char *kwlist[] = {"object", "stream", "indent", NULL};
     char *spaces = NULL;
 
@@ -361,11 +362,12 @@ static PyObject *py_dump(PYARGS)
         return NULL;
     }
 
-    spaces = __config_gen_config(indent, &config);
+    gen = yajl_gen_alloc(NULL);
+    spaces = __config_gen_config(indent, &gen);
     if (PyErr_Occurred()) {
         return NULL;
     }
-    result = _internal_stream_dump(object, stream, 0, config);
+    result = _internal_stream_dump(object, stream, 0, gen);
     if (spaces) {
         free(spaces);
     }
@@ -391,7 +393,7 @@ static PyObject *py_monkeypatch(PYARGS)
 }
 
 static struct PyMethodDef yajl_methods[] = {
-    {"dumps", (PyCFunctionWithKeywords)(py_dumps), METH_VARARGS | METH_KEYWORDS,
+    {"dumps", (PyCFunctionWithKeywords)py_dumps, METH_VARARGS | METH_KEYWORDS,
 "yajl.dumps(obj [, indent=None])\n\n\
 Returns an encoded JSON string of the specified `obj`\n\
 \n\

--- a/yajl.c
+++ b/yajl.c
@@ -39,6 +39,7 @@ static PyObject *empty_tuple;
 static PyMethodDef yajldecoder_methods[] = {
     {"decode", (PyCFunction)(py_yajldecoder_decode), METH_VARARGS, NULL},
     {"reset",  (PyCFunction)(py_yajldecoder_reset), METH_VARARGS, NULL},
+    {"iterdecode", (PyCFunction)(py_yajldecoder_iterdecode), METH_VARARGS, NULL},
     {NULL}
 };
 

--- a/yajl.c
+++ b/yajl.c
@@ -33,6 +33,9 @@
 
 #include "py_yajl.h"
 
+/* As the name says, an empty tuple. */
+static PyObject *empty_tuple;
+
 static PyMethodDef yajldecoder_methods[] = {
     {"decode", (PyCFunction)(py_yajldecoder_decode), METH_VARARGS, NULL},
     {NULL}
@@ -170,7 +173,7 @@ static PyObject *py_loads(PYARGS)
         return NULL;
     }
 
-    decoder = PyObject_Call((PyObject *)(&YajlDecoderType), NULL, NULL);
+    decoder = PyObject_CallObject((PyObject *)(&YajlDecoderType), empty_tuple);
     if (decoder == NULL) {
         return NULL;
     }
@@ -286,7 +289,7 @@ static PyObject *_internal_stream_load(PyObject *args, unsigned int blocking)
         return NULL;
 #endif
 
-    decoder = PyObject_Call((PyObject *)(&YajlDecoderType), NULL, NULL);
+    decoder = PyObject_CallObject((PyObject *)(&YajlDecoderType), empty_tuple);
     if (decoder == NULL) {
         return NULL;
     }

--- a/yajl.c
+++ b/yajl.c
@@ -328,10 +328,6 @@ static PyObject *py_load(PYARGS)
 {
     return _internal_stream_load(args, 1);
 }
-static PyObject *py_iterload(PYARGS)
-{
-    return _internal_stream_load(args, 0);
-}
 
 static PyObject *__write = NULL;
 static PyObject *_internal_stream_dump(PyObject *object, PyObject *stream, unsigned int blocking,
@@ -409,7 +405,7 @@ static PyObject *py_monkeypatch(PYARGS)
 }
 
 static struct PyMethodDef yajl_methods[] = {
-    {"dumps", (PyCFunctionWithKeywords)(py_dumps), METH_VARARGS | METH_KEYWORDS,
+    {"dumps", (PyCFunction)(py_dumps), METH_VARARGS | METH_KEYWORDS,
 "yajl.dumps(obj [, indent=None])\n\n\
 Returns an encoded JSON string of the specified `obj`\n\
 \n\
@@ -425,7 +421,7 @@ Returns a decoded object based on the given JSON `string`"},
 "yajl.load(fp)\n\n\
 Returns a decoded object based on the JSON read from the `fp` stream-like\n\
 object; *Note:* It is expected that `fp` supports the `read()` method"},
-    {"dump", (PyCFunctionWithKeywords)(py_dump), METH_VARARGS | METH_KEYWORDS,
+    {"dump", (PyCFunction)(py_dump), METH_VARARGS | METH_KEYWORDS,
 "yajl.dump(obj, fp [, indent=None])\n\n\
 Encodes the given `obj` and writes it to the `fp` stream-like object. \n\
 *Note*: It is expected that `fp` supports the `write()` method\n\
@@ -435,9 +431,6 @@ and object members will be pretty-printed with that indent level. \n\
 An indent level of 0 will only insert newlines. None (the default) \n\
 selects the most compact representation.\n\
 "},
-    /*
-     {"iterload", (PyCFunction)(py_iterload), METH_VARARGS, NULL},
-     */
     {"monkeypatch", (PyCFunction)(py_monkeypatch), METH_NOARGS,
 "yajl.monkeypatch()\n\n\
 Monkey-patches the yajl module into sys.modules as \"json\"\n\


### PR DESCRIPTION
This pull request:
1) Updates iainb's pull request(https://github.com/rtyler/py-yajl/pull/33) which no longer applies cleanly
2) Adds the ability to use a socket as a stream by supporting recv() if read() is not available
3) Adds the ability to create a decoder and then decode strings iteratively. This could be useful if you are reading a buffer of characters at a time from a non-blocking socket. A contrived example:

```
import yajl

chars = list("""[1,2,3,{"key": "value"}]{"number": 1}[null]""")

d = yajl.Decoder(allow_multiple_values=True)

for c in chars:
    results = d.iterdecode(c)
    for r in results:
        print r
    else:
        print "Reading..."
```

4) In ianb's iterator patch, fixed the refcount on passing in bufsize which could cause a segfault.
